### PR TITLE
docs: fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed:
 
-* Handle database connexion errors.
+* Handle database connection errors.
 * Alias cannot overwrite other commands.
 
 ## Version 1.0.0-alpha.1 (2022-08-16)

--- a/hyperfocus/services/session.py
+++ b/hyperfocus/services/session.py
@@ -15,7 +15,7 @@ class Session:
     Manage the session of the whole CLI.
 
     A new session is created each time a command is called. It primarily handles
-    database connexion and daily tracker service (which is the main service of
+    database connection and daily tracker service (which is the main service of
     the CLI).
     """
 
@@ -60,7 +60,7 @@ class Session:
 
     def teardown(self) -> None:
         """
-        Close the database connexion at Click teardown.
+        Close the database connection at Click teardown.
         """
         self._database.close()
 


### PR DESCRIPTION
Found via `codespell -H`