### PR TITLE
feat: add edit command

### DIFF
--- a/docs/source/commands.rst
+++ b/docs/source/commands.rst
@@ -117,7 +117,7 @@ Usage:
 
 Options:
 
-- ``f``, ``--force`` Force a task deletion
+- ``-f``, ``--force`` Force a task deletion
 - ``-h``, ``--help`` Command help.
 
 Example:
@@ -165,6 +165,42 @@ Example:
     :caption: mark tasks #3 and #4 as done.
 
     hyf done 3 4
+
+edit
+----
+
+Edit a task from the current working day. You can edit the title and the details of a task. If you want to edit only one attribute, you can use `-t` option for the title or `-d` option for the details. Note that only the details can contains multiple lines, if you edit the title with multiple lines, line breaks will be automatically removed.
+
+Usage:
+
+.. code-block:: bash
+
+    hyf edit [OPTIONS] <id>
+
+- **<id>** The id of the task you want to edit. If you don't remember the id of the task, leave it empty, **Hyperfocus** will display you a little reminder.
+
+Options:
+
+- ``-t``, ``--title`` Edit the title of the task only.
+- ``-d``, ``--details`` Edit the details of the task only.
+- ``-h``, ``--help`` Command help.
+
+Example:
+
+.. code-block:: bash
+    :caption: Edit title and details for task #3.
+
+    hyf edit 3
+
+.. code-block:: bash
+    :caption: Edit title and details for task #3 and #4.
+
+    hyf edit 3 4
+
+.. code-block:: bash
+    :caption: Edit title only for task #3.
+
+    hyf edit --title 3
 
 init
 ----

--- a/src/hyperfocus/console/cli.py
+++ b/src/hyperfocus/console/cli.py
@@ -5,6 +5,7 @@ from hyperfocus.console.commands.config import config
 from hyperfocus.console.commands.copy import copy
 from hyperfocus.console.commands.delete import delete
 from hyperfocus.console.commands.done import done
+from hyperfocus.console.commands.edit import edit
 from hyperfocus.console.commands.init import init
 from hyperfocus.console.commands.log import log
 from hyperfocus.console.commands.main import hyf
@@ -23,6 +24,7 @@ hyf.add_commands(
         copy,
         delete,
         done,
+        edit,
         init,
         log,
         reset,

--- a/src/hyperfocus/console/commands/_shortcodes.py
+++ b/src/hyperfocus/console/commands/_shortcodes.py
@@ -47,16 +47,20 @@ class TaskCommands:
 
         return task
 
-    def update_tasks(
-        self, task_ids: tuple[int, ...], status: TaskStatus, prompt_text: str
-    ) -> None:
+    def get_tasks(self, task_ids: tuple[int, ...], prompt_text: str) -> list[Task]:
         if not task_ids:
             task_id = self.pick_task(prompt_text=prompt_text)
             task_ids = (task_id,)
 
+        tasks = []
         for task_id in task_ids:
-            task = self.get_task(task_id=task_id)
+            task = self.get_task(task_id)
+            tasks.append(task)
 
+        return tasks
+
+    def update_tasks_status(self, tasks: list[Task], status: TaskStatus) -> None:
+        for task in tasks:
             if task.status == status.value:
                 printer.echo(
                     WarningNotification(
@@ -66,7 +70,8 @@ class TaskCommands:
                 )
                 continue
 
-            self.session.daily_tracker.update_task(task=task, status=status)
+            task.status = status
+            self.session.daily_tracker.update_task(task=task)
 
             text_suffix = "reset" if status == TaskStatus.TODO else status.name.lower()
             printer.echo(

--- a/src/hyperfocus/console/commands/delete.py
+++ b/src/hyperfocus/console/commands/delete.py
@@ -35,8 +35,5 @@ def delete(task_ids: tuple[int, ...], force: bool) -> None:
                 )
             )
     else:
-        task_cmd.update_tasks(
-            task_ids=task_ids,
-            status=TaskStatus.DELETED,
-            prompt_text="Delete task",
-        )
+        tasks = task_cmd.get_tasks(task_ids=task_ids, prompt_text="Delete task")
+        task_cmd.update_tasks_status(tasks=tasks, status=TaskStatus.DELETED)

--- a/src/hyperfocus/console/commands/done.py
+++ b/src/hyperfocus/console/commands/done.py
@@ -13,8 +13,5 @@ def done(task_ids: tuple[int, ...]) -> None:
     session = get_current_session()
     task_cmd = TaskCommands(session)
 
-    task_cmd.update_tasks(
-        task_ids=task_ids,
-        status=TaskStatus.DONE,
-        prompt_text="Validate task",
-    )
+    tasks = task_cmd.get_tasks(task_ids=task_ids, prompt_text="Validate task")
+    task_cmd.update_tasks_status(tasks=tasks, status=TaskStatus.DONE)

--- a/src/hyperfocus/console/commands/edit.py
+++ b/src/hyperfocus/console/commands/edit.py
@@ -31,7 +31,7 @@ def edit(task_ids: tuple[int, ...], title: bool, details: bool) -> None:
     session = get_current_session()
     task_cmd = TaskCommands(session)
 
-    if not all([title, details]):
+    if not any([title, details]):
         title = details = True
 
     tasks = task_cmd.get_tasks(task_ids=task_ids, prompt_text="Edit task")
@@ -58,6 +58,6 @@ def edit(task_ids: tuple[int, ...], title: bool, details: bool) -> None:
         session.daily_tracker.update_task(task=task)
         printer.echo(
             SuccessNotification(
-                text=f"{formatter.task(task=task, show_prefix=True)} [{style.INFO}]edited[/]",
+                text=f"{formatter.task(task=task, show_prefix=True)} [{style.INFO}]edited[/].",
             )
         )

--- a/src/hyperfocus/console/commands/edit.py
+++ b/src/hyperfocus/console/commands/edit.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import click
+
+from hyperfocus.console.commands._shortcodes import TaskCommands
+from hyperfocus.services.session import get_current_session
+from hyperfocus.termui import formatter
+from hyperfocus.termui import printer
+from hyperfocus.termui import style
+from hyperfocus.termui.components import SuccessNotification
+from hyperfocus.termui.components import WarningNotification
+
+
+@click.command(help="Edit task from current working day")
+@click.argument("task_ids", metavar="<id>", required=False, nargs=-1, type=click.INT)
+@click.option(
+    "-t",
+    "--title",
+    "title",
+    is_flag=True,
+    help="Edit task title.",
+)
+@click.option(
+    "-d",
+    "--details",
+    "details",
+    is_flag=True,
+    help="Edit task details.",
+)
+def edit(task_ids: tuple[int, ...], title: bool, details: bool) -> None:
+    session = get_current_session()
+    task_cmd = TaskCommands(session)
+
+    if not all([title, details]):
+        title = details = True
+
+    tasks = task_cmd.get_tasks(task_ids=task_ids, prompt_text="Edit task")
+    for task in tasks:
+        edited = False  # Flag to check if task was edited
+
+        if title:
+            edited = (
+                task_cmd.edit_task(task=task, field="title", splitlines=True) or edited
+            )
+
+        if details:
+            edited = task_cmd.edit_task(task=task, field="details") or edited
+
+        if edited is False:
+            printer.echo(
+                WarningNotification(
+                    f"{formatter.task(task=task, show_prefix=True)} "
+                    f"[{style.INFO}]unchanged[/]."
+                )
+            )
+            continue
+
+        session.daily_tracker.update_task(task=task)
+        printer.echo(
+            SuccessNotification(
+                text=f"{formatter.task(task=task, show_prefix=True)} [{style.INFO}]edited[/]",
+            )
+        )

--- a/src/hyperfocus/console/commands/reset.py
+++ b/src/hyperfocus/console/commands/reset.py
@@ -13,8 +13,5 @@ def reset(task_ids: tuple[int, ...]) -> None:
     session = get_current_session()
     task_cmd = TaskCommands(session)
 
-    task_cmd.update_tasks(
-        task_ids=task_ids,
-        status=TaskStatus.TODO,
-        prompt_text="Reset task",
-    )
+    tasks = task_cmd.get_tasks(task_ids=task_ids, prompt_text="Reset task")
+    task_cmd.update_tasks_status(tasks=tasks, status=TaskStatus.TODO)

--- a/src/hyperfocus/services/daily_tracker.py
+++ b/src/hyperfocus/services/daily_tracker.py
@@ -149,9 +149,8 @@ class DailyTracker:
         task.delete_instance()
 
     @staticmethod
-    def update_task(task: Task, status: TaskStatus) -> None:
+    def update_task(task: Task) -> None:
         """
         Persist an updated task.
         """
-        task.status = status
         task.save()

--- a/tests/test_console/test_commands/test_edit.py
+++ b/tests/test_console/test_commands/test_edit.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import pytest
+
+from click.testing import CliRunner
+
+from hyperfocus.termui import icons
+
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def mock_click_edit(mocker):
+    """Click edit mock.
+
+    Simulates the click.edit function by replacing the first line of the input with the
+    values in the replace_values list.
+    """
+
+    class MockEdit:
+        def __init__(self, side_effect: list[str | None]):
+            self.side_effect = iter(side_effect)
+
+        def __call__(self, value):
+            effect = next(self.side_effect)
+
+            if effect is None:
+                # If the replacement value is None, return the original value.
+                return effect
+
+            lines = value.split("\n")
+            lines[0] = effect
+            return "\n".join(lines)
+
+    def configure_edit_mock(side_effect: list[str | None]):
+        mocker.patch("click.edit", new_callable=MockEdit, side_effect=side_effect)
+
+    return configure_edit_mock
+
+
+@pytest.mark.functional
+def test_edit(mock_click_edit, cli):
+    result = runner.invoke(cli, ["edit"])
+
+    assert result.exit_code == 0
+    assert result.output == "No tasks for today...\n"
+
+    runner.invoke(cli, ["add", "foo"])
+
+    result = runner.invoke(cli, ["edit"], input="12\n")
+
+    expected = (
+        "\n"
+        "  #   tasks   details  \n"
+        " --------------------- \n"
+        f"  1   {icons.TASK_STATUS} foo      {icons.NO_DETAILS}     \n"
+        "\n"
+        f"{icons.PROMPT} Edit task: 12\n"
+        f"{icons.ERROR}(error) Task 12 does not exist.\n"
+    )
+    assert result.exit_code == 1
+    assert result.output == expected
+
+    mock_click_edit(["foobar", "foobaz"])
+
+    result = runner.invoke(cli, ["edit", "1"])
+
+    assert result.exit_code == 0
+    assert result.output == (
+        f"{icons.SUCCESS}(success) Task: #1 {icons.TASK_STATUS} foobar edited.\n"
+    )
+
+    mock_click_edit([None])
+
+    result = runner.invoke(cli, ["edit", "1", "-t"])
+
+    assert result.exit_code == 0
+    assert result.output == (
+        f"{icons.WARNING}(warning) Task: #1 {icons.TASK_STATUS} foobar unchanged.\n"
+    )
+
+    mock_click_edit(["foobaz foo"])
+
+    result = runner.invoke(cli, ["edit", "1", "-d"])
+
+    assert result.exit_code == 0
+    assert result.output == (
+        f"{icons.SUCCESS}(success) Task: #1 {icons.TASK_STATUS} foobar edited.\n"
+    )
+
+    mock_click_edit(["foo", "bar"])
+
+    result = runner.invoke(cli, ["edit", "1", "-t", "-d"])
+
+    assert result.exit_code == 0
+    assert result.output == (
+        f"{icons.SUCCESS}(success) Task: #1 {icons.TASK_STATUS} foo edited.\n"
+    )

--- a/tests/test_services/test_daily_tracker.py
+++ b/tests/test_services/test_daily_tracker.py
@@ -90,11 +90,12 @@ def test_daily_tracker_service_get_tasks_with_exclude_status_filter(test_databas
 
 def test_daily_tracker_service_update_task(test_database):
     daily_tracker = DailyTracker.from_date(datetime.date(2022, 1, 5))
-    _task = daily_tracker.create_task(title="Test add task", details="Test add details")
+    task = daily_tracker.create_task(title="Test add task", details="Test add details")
+    task.status = TaskStatus.DONE
 
-    daily_tracker.update_task(task=_task, status=TaskStatus.DONE)
+    daily_tracker.update_task(task=task)
 
-    updated_task = daily_tracker.get_task(task_id=_task.id)
+    updated_task = daily_tracker.get_task(task_id=task.id)
     assert updated_task.status == TaskStatus.DONE
 
 


### PR DESCRIPTION
Add `edit` command in order to be able to edit title and details from already created tasks.

`hyf edit 1` will edit task 1.
`hyf edit 1 2` will edit task 1 and 2.
`hyf edit 1 -t` will edit title for task 1.
`hyf edit 1 -d` will edit details for task 1.
`hyf edit 1 -t -d` will do the same as `hyf edit 1`.